### PR TITLE
Harden air quality fetch and refresh on wake

### DIFF
--- a/Air/AirQuality.swift
+++ b/Air/AirQuality.swift
@@ -46,12 +46,11 @@ struct Category: Codable {
 
 
 class AirQuality {
+    static let defaultZipcode = "94115"
+
     private var url: URL {
-        let urlString = "http://www.airnowapi.org/aq/observation/zipCode/current/?format=application/json&API_KEY=\(Secrets.apiKey)&zipCode="
-        guard let zipcode = zipcode else {
-            return URL(string: urlString + "94115")!
-        }
-        return URL(string: urlString + zipcode)!
+        let urlString = "https://www.airnowapi.org/aq/observation/zipCode/current/?format=application/json&API_KEY=\(Secrets.apiKey)&zipCode="
+        return URL(string: urlString + (zipcode ?? AirQuality.defaultZipcode))!
     }
     
     var zipcode: String? {
@@ -69,18 +68,15 @@ class AirQuality {
                 print("err: \(err.code)")
             }
             let decoder = JSONDecoder()
-            guard let data = data else { fatalError() }
-            guard let json = try? decoder.decode(AirQualityData.self, from: data) else { fatalError() }
-            
-            for quality in json {
-                print("quality: \(quality)")
+            guard let data = data,
+                let json = try? decoder.decode(AirQualityData.self, from: data),
+                let worst = json.max(by: { $0.aqi < $1.aqi }) else {
+                    completion("N/A", Category(number: -1, name: "n/a"))
+                    return
             }
-            guard json.isEmpty == false else {
-                completion("N/A", Category.init(number: -1, name: "n/a"))
-                return
-            }
-            
-            completion("\(json[1].aqi)", json[1].category)
+            // Report the worst reading across all parameters (e.g. PM2.5 vs ozone),
+            // which is how the overall AQI for an area is defined.
+            completion("\(worst.aqi)", worst.category)
         }
     }
     

--- a/Air/AppDelegate.swift
+++ b/Air/AppDelegate.swift
@@ -58,11 +58,22 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         
         updateAirQuality()
         startTimer()
+
+        // Refresh immediately when the machine wakes, so a laptop that's been
+        // asleep doesn't sit showing a stale reading until the next timer tick.
+        NSWorkspace.shared.notificationCenter.addObserver(
+            self,
+            selector: #selector(updateAirQuality),
+            name: NSWorkspace.didWakeNotification,
+            object: nil
+        )
     }
-    
+
     func startTimer() {
         self.timer?.invalidate()
-        self.timer = Timer.scheduledTimer(timeInterval: 600, target: self, selector: #selector(updateAirQuality), userInfo: nil, repeats: true)
+        let timer = Timer.scheduledTimer(timeInterval: 600, target: self, selector: #selector(updateAirQuality), userInfo: nil, repeats: true)
+        timer.tolerance = 60 // let the system coalesce the timer to save power
+        self.timer = timer
     }
     
     @objc func updateAirQuality() {

--- a/Air/MenuViewController.swift
+++ b/Air/MenuViewController.swift
@@ -26,11 +26,7 @@ class MenuViewController: NSViewController {
         let date = formatter.string(from: self.date)
         self.dateLabel?.cell?.title = date
         zipcodeLabel.delegate = self
-        if let zipcode = UserDefaults.standard.zipcode {
-            self.zipcodeLabel.cell?.title = zipcode
-        } else {
-            self.zipcodeLabel.cell?.title = "94115"
-        }
+        self.zipcodeLabel.cell?.title = UserDefaults.standard.zipcode ?? AirQuality.defaultZipcode
 
     }
     


### PR DESCRIPTION
This PR improves reliability of the menu bar app so it can run untouched for long stretches without dying.

## Changes
- **Remove crash paths.** `getAirQuality` used `fatalError()` when the network was down or the API returned an error/empty payload, and it read a fixed `json[1]` index that crashed when an area reports only a single parameter (e.g. PM2.5 but not ozone). These now fall back gracefully to `N/A`.
- **Report the worst AQI** across all reported parameters instead of a fixed index — this matches how an area's overall AQI is actually defined.
- **Use HTTPS** so the API key and zip code aren't sent in cleartext.
- **Refresh on wake from sleep** (`NSWorkspace.didWakeNotification`) so a laptop that's been asleep doesn't sit showing a stale reading until the next timer tick.
- **Timer tolerance** added so the system can coalesce the 10-minute poll and save power.
- **Shared `defaultZipcode` constant** instead of duplicating `"94115"` across files.

No UI or behavior changes for the happy path; these are reliability and correctness fixes.