### PR TITLE
Add level-change notifications and a 24-hour trend chart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,8 @@
 Secrets.swift
+
+# Xcode build artifacts & user state
+build/
+DerivedData/
+*.xcuserstate
+xcuserdata/
+.DS_Store

--- a/Air/AirQuality.swift
+++ b/Air/AirQuality.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import UserNotifications
 
 typealias AirQualityData = [AirQualityDatum]
 
@@ -62,7 +63,7 @@ class AirQuality {
         
     }
     
-    func getAirQuality(completion: @escaping ((String, Category) -> ())) {
+    func getAirQuality(completion: @escaping ((String, Category, AirQualityDatum?) -> ())) {
         self.unauthenticatedRequest { (data, err) in
             if let err = err as? NSError {
                 print("err: \(err.code)")
@@ -71,12 +72,12 @@ class AirQuality {
             guard let data = data,
                 let json = try? decoder.decode(AirQualityData.self, from: data),
                 let worst = json.max(by: { $0.aqi < $1.aqi }) else {
-                    completion("N/A", Category(number: -1, name: "n/a"))
+                    completion("N/A", Category(number: -1, name: "n/a"), nil)
                     return
             }
             // Report the worst reading across all parameters (e.g. PM2.5 vs ozone),
             // which is how the overall AQI for an area is defined.
-            completion("\(worst.aqi)", worst.category)
+            completion("\(worst.aqi)", worst.category, worst)
         }
     }
     
@@ -100,5 +101,100 @@ class AirQuality {
             completion(data, nil)
         }
         task.resume()
+    }
+}
+
+
+// MARK: - History
+
+/// One point on the trend chart.
+struct AQIReading: Codable {
+    let date: Date
+    let aqi: Int
+    let categoryNumber: Int
+}
+
+/// Persists a rolling window of recent AQI readings, used to draw the trend chart.
+final class AQIHistory {
+    static let shared = AQIHistory()
+    private let key = "aqiHistory"
+    private let window: TimeInterval = 24 * 60 * 60 // keep a rolling 24 hours
+
+    private init() {}
+
+    var readings: [AQIReading] {
+        guard let data = UserDefaults.standard.data(forKey: key),
+            let decoded = try? JSONDecoder().decode([AQIReading].self, from: data) else {
+                return []
+        }
+        return decoded
+    }
+
+    @discardableResult
+    func record(aqi: Int, categoryNumber: Int, date: Date = Date()) -> [AQIReading] {
+        var all = readings
+        all.append(AQIReading(date: date, aqi: aqi, categoryNumber: categoryNumber))
+        // Keep only readings from the last 24 hours (robust to sleep gaps and
+        // any change in the poll interval).
+        let cutoff = date.addingTimeInterval(-window)
+        all = all.filter { $0.date >= cutoff }
+        if let data = try? JSONEncoder().encode(all) {
+            UserDefaults.standard.set(data, forKey: key)
+        }
+        return all
+    }
+
+    /// Discards all history. Call when the location (zip code) changes so
+    /// readings from different places aren't charted together.
+    func clear() {
+        UserDefaults.standard.removeObject(forKey: key)
+    }
+}
+
+
+// MARK: - Notifications
+
+/// Posts a local notification when the AQI category changes (e.g. Good -> Moderate),
+/// rather than on every poll, so the user isn't spammed while conditions are steady.
+final class Notifier {
+    static let shared = Notifier()
+    private let lastCategoryKey = "lastNotifiedCategory"
+
+    private init() {}
+
+    func requestAuthorization() {
+        // UserNotifications requires macOS 10.14+; on older systems this is a no-op
+        // and the app simply runs without change notifications.
+        guard #available(macOS 10.14, *) else { return }
+        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound]) { _, error in
+            if let error = error {
+                print("notification auth error: \(error)")
+            }
+        }
+    }
+
+    /// Forgets the last category so the next reading establishes a fresh
+    /// baseline (used when the location changes).
+    func reset() {
+        UserDefaults.standard.removeObject(forKey: lastCategoryKey)
+    }
+
+    func notifyIfCategoryChanged(area: String, aqi: Int, category: Category) {
+        let defaults = UserDefaults.standard
+        let previous = defaults.object(forKey: lastCategoryKey) as? Int
+        defaults.set(category.number, forKey: lastCategoryKey)
+
+        // Skip the very first reading and any poll where the category is unchanged.
+        guard let previous = previous, previous != category.number else { return }
+        guard #available(macOS 10.14, *) else { return }
+
+        let content = UNMutableNotificationContent()
+        content.title = "\(area): \(category.name)"
+        let direction = category.number > previous ? "worsened" : "improved"
+        content.body = "Air quality \(direction) — AQI is now \(aqi)."
+        content.sound = UNNotificationSound.default()
+
+        let request = UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: nil)
+        UNUserNotificationCenter.current().add(request, withCompletionHandler: nil)
     }
 }

--- a/Air/AppDelegate.swift
+++ b/Air/AppDelegate.swift
@@ -56,6 +56,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         popover.animates = true
         popover.behavior = .transient
         
+        Notifier.shared.requestAuthorization()
         updateAirQuality()
         startTimer()
 
@@ -77,7 +78,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
     
     @objc func updateAirQuality() {
-        AirQuality.shared.getAirQuality { (aqi, category) in
+        AirQuality.shared.getAirQuality { (aqi, category, datum) in
             DispatchQueue.main.async {
                 if let button = self.statusItem.button {
                     self.statusItem.button?.highlight(true)
@@ -108,6 +109,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                         button.attributedTitle = NSAttributedString(string: aqi, attributes: [ NSAttributedStringKey.foregroundColor : NSColor.white, NSAttributedStringKey.paragraphStyle : pstyle ])
                     }
                 }
+                // Record the reading for the trend chart and notify on category changes.
+                if let datum = datum {
+                    AQIHistory.shared.record(aqi: datum.aqi, categoryNumber: datum.category.number)
+                    Notifier.shared.notifyIfCategoryChanged(area: datum.reportingArea, aqi: datum.aqi, category: datum.category)
+                }
+                self.menuVew?.updateChart()
                 self.menuVew?.updateDateLabel()
             }
         }

--- a/Air/MenuViewController.swift
+++ b/Air/MenuViewController.swift
@@ -19,7 +19,9 @@ class MenuViewController: NSViewController {
     
     @IBOutlet weak var dateLabel: NSTextField?
     @IBOutlet weak var zipcodeLabel: NSTextField!
-    
+
+    private var sparkline: SparklineView?
+
     var date: Date = Date()
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -28,6 +30,37 @@ class MenuViewController: NSViewController {
         zipcodeLabel.delegate = self
         self.zipcodeLabel.cell?.title = UserDefaults.standard.zipcode ?? AirQuality.defaultZipcode
 
+        setupChart()
+        updateChart()
+    }
+
+    /// Grows the popover and adds the trend chart in the new space above the
+    /// existing controls. Subview autoresizing is turned off so the fixed-frame
+    /// controls from the xib stay exactly where they are.
+    private func setupChart() {
+        let chartHeight: CGFloat = 80
+        let topMargin: CGFloat = 8
+
+        view.autoresizesSubviews = false
+
+        // Sit the chart just above the top-most control (the zip code field) so
+        // there's no dead space between the chart and the controls below it.
+        let chartBottom = zipcodeLabel.frame.maxY + 4
+        var frame = view.frame
+        frame.size.height = chartBottom + chartHeight + topMargin
+        view.frame = frame
+
+        let chart = SparklineView(frame: NSRect(x: 12,
+                                                y: chartBottom,
+                                                width: view.bounds.width - 24,
+                                                height: chartHeight))
+        chart.autoresizingMask = [.width, .minYMargin]
+        view.addSubview(chart)
+        self.sparkline = chart
+    }
+
+    func updateChart() {
+        sparkline?.readings = AQIHistory.shared.readings
     }
     
     @IBAction func quit(_ sender: NSButton) {
@@ -35,17 +68,26 @@ class MenuViewController: NSViewController {
     }
     
     @IBAction func zipcodeDidChange(_ sender: NSTextField) {
-        guard let text = sender.cell?.title else { return }
-        guard validZipCode(postalCode: text) else { return }
-        UserDefaults.standard.zipcode = text
-        UserDefaults.standard.synchronize()
+        applyZipcode(sender.stringValue)
     }
-    
+
     func textFieldDidChange(_ sender: NSTextField) {
-        guard let text = sender.cell?.title else { return }
-        guard validZipCode(postalCode: text) else { return }
-        UserDefaults.standard.zipcode = text
+        applyZipcode(sender.stringValue)
+    }
+
+    /// Single entry point for a zip-code edit. Persists the value and, when the
+    /// location actually changes, resets the chart history and notification
+    /// baseline so data from different places isn't mixed together.
+    private func applyZipcode(_ newZip: String) {
+        guard validZipCode(postalCode: newZip) else { return }
+        let previous = UserDefaults.standard.zipcode
+        UserDefaults.standard.zipcode = newZip
         UserDefaults.standard.synchronize()
+        if newZip != previous {
+            AQIHistory.shared.clear()
+            Notifier.shared.reset()
+            updateChart()
+        }
         refresh()
     }
     
@@ -75,10 +117,140 @@ class MenuViewController: NSViewController {
 extension MenuViewController: NSTextFieldDelegate {
     public override func controlTextDidChange(_ obj: Notification) {
         if let textField = obj.object as? NSTextField, self.zipcodeLabel.identifier == textField.identifier {
-            guard validZipCode(postalCode: textField.stringValue) else { return }
-            UserDefaults.standard.zipcode = textField.stringValue
-            UserDefaults.standard.synchronize()
-            refresh()
+            applyZipcode(textField.stringValue)
+        }
+    }
+}
+
+
+/// A small trend chart of recent AQI readings, drawn with Core Graphics so it
+/// adds no dependencies and keeps the app's deployment target and universal build.
+final class SparklineView: NSView {
+
+    var readings: [AQIReading] = [] {
+        didSet { needsDisplay = true }
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        super.draw(dirtyRect)
+
+        // No background — draw a bare sparkline directly over the popover.
+        guard readings.count >= 2 else {
+            drawMessage("Collecting air quality history…", atTop: false)
+            return
+        }
+
+        // Reserve a band at the top for the label. It's wide enough that neither
+        // the line nor its ~9px glow halo reaches up into the text.
+        let plot = NSRect(x: bounds.minX + 8,
+                          y: bounds.minY + 8,
+                          width: bounds.width - 16,
+                          height: bounds.height - 8 - 30)
+        let values = readings.map { CGFloat($0.aqi) }
+        // Floor the scale at 50 so a stretch of "Good" readings isn't blown up to full height.
+        let scale = max(values.max() ?? 1, 50)
+
+        func point(_ i: Int) -> NSPoint {
+            let x = plot.minX + plot.width * CGFloat(i) / CGFloat(readings.count - 1)
+            let y = plot.minY + plot.height * (values[i] / scale)
+            return NSPoint(x: x, y: y)
+        }
+
+        guard let ctx = NSGraphicsContext.current?.cgContext else { return }
+        let rgb = CGColorSpaceCreateDeviceRGB()
+
+        // Bold neon palette.
+        let neonCyan = NSColor(red: 0.0, green: 1.0, blue: 0.94, alpha: 1)
+        let neonMagenta = NSColor(red: 1.0, green: 0.12, blue: 0.82, alpha: 1)
+
+        // Line path (reused for the glow and the gradient fill).
+        let linePath = CGMutablePath()
+        linePath.move(to: point(0))
+        for i in 1..<readings.count { linePath.addLine(to: point(i)) }
+
+        // Neon glow under the line.
+        let areaPath = CGMutablePath()
+        areaPath.move(to: CGPoint(x: plot.minX, y: plot.minY))
+        for i in readings.indices { areaPath.addLine(to: point(i)) }
+        areaPath.addLine(to: CGPoint(x: plot.maxX, y: plot.minY))
+        areaPath.closeSubpath()
+        ctx.saveGState()
+        ctx.addPath(areaPath)
+        ctx.clip()
+        let areaGradient = CGGradient(colorsSpace: rgb, colors: [
+            neonCyan.withAlphaComponent(0.35).cgColor,
+            neonMagenta.withAlphaComponent(0.02).cgColor
+        ] as CFArray, locations: [0, 1])!
+        ctx.drawLinearGradient(areaGradient,
+                               start: CGPoint(x: plot.minX, y: plot.maxY),
+                               end: CGPoint(x: plot.minX, y: plot.minY),
+                               options: [])
+        ctx.restoreGState()
+
+        // Stroke outline of the line, used twice: once for the glow, once clipped for the gradient.
+        let stroked = linePath.copy(strokingWithWidth: 2.6, lineCap: .round, lineJoin: .round, miterLimit: 10)
+
+        // 1) Glow halo.
+        ctx.saveGState()
+        ctx.setShadow(offset: .zero, blur: 9, color: neonCyan.withAlphaComponent(0.9).cgColor)
+        ctx.addPath(stroked)
+        ctx.setFillColor(neonCyan.cgColor)
+        ctx.fillPath()
+        ctx.restoreGState()
+
+        // 2) Neon cyan -> magenta gradient along the line.
+        ctx.saveGState()
+        ctx.addPath(stroked)
+        ctx.clip()
+        let lineGradient = CGGradient(colorsSpace: rgb, colors: [
+            neonCyan.cgColor, neonMagenta.cgColor
+        ] as CFArray, locations: [0, 1])!
+        ctx.drawLinearGradient(lineGradient,
+                               start: CGPoint(x: plot.minX, y: plot.midY),
+                               end: CGPoint(x: plot.maxX, y: plot.midY),
+                               options: [.drawsBeforeStartLocation, .drawsAfterEndLocation])
+        ctx.restoreGState()
+
+        // Glowing dot on the latest reading, colored by its category.
+        let last = readings.count - 1
+        let p = point(last)
+        let dotColor = SparklineView.color(forCategory: readings[last].categoryNumber)
+        ctx.saveGState()
+        ctx.setShadow(offset: .zero, blur: 7, color: dotColor.cgColor)
+        ctx.setFillColor(dotColor.cgColor)
+        ctx.addPath(CGPath(ellipseIn: NSRect(x: p.x - 3.5, y: p.y - 3.5, width: 7, height: 7), transform: nil))
+        ctx.fillPath()
+        ctx.restoreGState()
+
+        let spanHours = readings[last].date.timeIntervalSince(readings[0].date) / 3600
+        let span = spanHours >= 1 ? "\(Int(spanHours.rounded()))h" : "<1h"
+        drawMessage("AQI \(readings[last].aqi) · \(span) / 24h", atTop: true)
+    }
+
+    private func drawMessage(_ text: String, atTop: Bool) {
+        let style = NSMutableParagraphStyle()
+        style.alignment = .center
+        let attrs: [NSAttributedStringKey: Any] = [
+            .font: NSFont.systemFont(ofSize: 10),
+            .foregroundColor: NSColor.secondaryLabelColor,
+            .paragraphStyle: style
+        ]
+        let size = (text as NSString).size(withAttributes: attrs)
+        let y = atTop ? bounds.maxY - size.height - 4 : bounds.midY - size.height / 2
+        let rect = NSRect(x: bounds.minX, y: y, width: bounds.width, height: size.height)
+        (text as NSString).draw(in: rect, withAttributes: attrs)
+    }
+
+    /// Matches the menu-bar color scale used in AppDelegate.
+    static func color(forCategory number: Int) -> NSColor {
+        switch number {
+        case 0, 1: return .systemGreen
+        case 2: return .systemYellow
+        case 3: return .systemOrange
+        case 4: return .systemRed
+        case 5: return .systemPurple
+        case 6: return NSColor(red: 0.49, green: 0.0, blue: 0.13, alpha: 1)
+        default: return .systemGray
         }
     }
 }

--- a/Air/MenuViewController.swift
+++ b/Air/MenuViewController.swift
@@ -157,64 +157,46 @@ final class SparklineView: NSView {
         }
 
         guard let ctx = NSGraphicsContext.current?.cgContext else { return }
-        let rgb = CGColorSpaceCreateDeviceRGB()
 
-        // Bold neon palette.
-        let neonCyan = NSColor(red: 0.0, green: 1.0, blue: 0.94, alpha: 1)
-        let neonMagenta = NSColor(red: 1.0, green: 0.12, blue: 0.82, alpha: 1)
+        func categoryColor(_ i: Int) -> NSColor {
+            return SparklineView.color(forCategory: readings[i].categoryNumber)
+        }
 
-        // Line path (reused for the glow and the gradient fill).
-        let linePath = CGMutablePath()
-        linePath.move(to: point(0))
-        for i in 1..<readings.count { linePath.addLine(to: point(i)) }
+        // Soft filled band under each segment, tinted with that segment's
+        // category color so the chart's fill matches the menu-bar color.
+        for i in 0..<readings.count - 1 {
+            let p0 = point(i), p1 = point(i + 1)
+            let band = NSBezierPath()
+            band.move(to: NSPoint(x: p0.x, y: plot.minY))
+            band.line(to: p0)
+            band.line(to: p1)
+            band.line(to: NSPoint(x: p1.x, y: plot.minY))
+            band.close()
+            categoryColor(i).withAlphaComponent(0.18).setFill()
+            band.fill()
+        }
 
-        // Neon glow under the line.
-        let areaPath = CGMutablePath()
-        areaPath.move(to: CGPoint(x: plot.minX, y: plot.minY))
-        for i in readings.indices { areaPath.addLine(to: point(i)) }
-        areaPath.addLine(to: CGPoint(x: plot.maxX, y: plot.minY))
-        areaPath.closeSubpath()
-        ctx.saveGState()
-        ctx.addPath(areaPath)
-        ctx.clip()
-        let areaGradient = CGGradient(colorsSpace: rgb, colors: [
-            neonCyan.withAlphaComponent(0.35).cgColor,
-            neonMagenta.withAlphaComponent(0.02).cgColor
-        ] as CFArray, locations: [0, 1])!
-        ctx.drawLinearGradient(areaGradient,
-                               start: CGPoint(x: plot.minX, y: plot.maxY),
-                               end: CGPoint(x: plot.minX, y: plot.minY),
-                               options: [])
-        ctx.restoreGState()
-
-        // Stroke outline of the line, used twice: once for the glow, once clipped for the gradient.
-        let stroked = linePath.copy(strokingWithWidth: 2.6, lineCap: .round, lineJoin: .round, miterLimit: 10)
-
-        // 1) Glow halo.
-        ctx.saveGState()
-        ctx.setShadow(offset: .zero, blur: 9, color: neonCyan.withAlphaComponent(0.9).cgColor)
-        ctx.addPath(stroked)
-        ctx.setFillColor(neonCyan.cgColor)
-        ctx.fillPath()
-        ctx.restoreGState()
-
-        // 2) Neon cyan -> magenta gradient along the line.
-        ctx.saveGState()
-        ctx.addPath(stroked)
-        ctx.clip()
-        let lineGradient = CGGradient(colorsSpace: rgb, colors: [
-            neonCyan.cgColor, neonMagenta.cgColor
-        ] as CFArray, locations: [0, 1])!
-        ctx.drawLinearGradient(lineGradient,
-                               start: CGPoint(x: plot.minX, y: plot.midY),
-                               end: CGPoint(x: plot.maxX, y: plot.midY),
-                               options: [.drawsBeforeStartLocation, .drawsAfterEndLocation])
-        ctx.restoreGState()
+        // The trend line, drawn one segment at a time so its color and glow
+        // track the AQI category — the same colors the menu bar uses.
+        ctx.setLineWidth(2.4)
+        ctx.setLineCap(.round)
+        ctx.setLineJoin(.round)
+        for i in 0..<readings.count - 1 {
+            let color = categoryColor(i)
+            ctx.saveGState()
+            ctx.setShadow(offset: .zero, blur: 6, color: color.withAlphaComponent(0.8).cgColor)
+            ctx.setStrokeColor(color.cgColor)
+            ctx.beginPath()
+            ctx.move(to: point(i))
+            ctx.addLine(to: point(i + 1))
+            ctx.strokePath()
+            ctx.restoreGState()
+        }
 
         // Glowing dot on the latest reading, colored by its category.
         let last = readings.count - 1
         let p = point(last)
-        let dotColor = SparklineView.color(forCategory: readings[last].categoryNumber)
+        let dotColor = categoryColor(last)
         ctx.saveGState()
         ctx.setShadow(offset: .zero, blur: 7, color: dotColor.cgColor)
         ctx.setFillColor(dotColor.cgColor)
@@ -241,16 +223,17 @@ final class SparklineView: NSView {
         (text as NSString).draw(in: rect, withAttributes: attrs)
     }
 
-    /// Matches the menu-bar color scale used in AppDelegate.
+    /// The exact colors AppDelegate paints behind the menu-bar AQI value, so
+    /// the chart reads as the same scale.
     static func color(forCategory number: Int) -> NSColor {
         switch number {
-        case 0, 1: return .systemGreen
-        case 2: return .systemYellow
-        case 3: return .systemOrange
-        case 4: return .systemRed
-        case 5: return .systemPurple
-        case 6: return NSColor(red: 0.49, green: 0.0, blue: 0.13, alpha: 1)
-        default: return .systemGray
+        case 0, 1: return .green
+        case 2: return .yellow
+        case 3: return .orange
+        case 4: return .red
+        case 5: return .purple
+        case 6: return .black
+        default: return .gray
         }
     }
 }


### PR DESCRIPTION
Adds two features to the menu bar app, with no new dependencies and the deployment target unchanged (10.13).

## Features
- **Level-change notifications** — posts a local notification when the AQI *category* changes (e.g. Good → Moderate), noting whether air quality *worsened* or *improved*. Steady conditions stay quiet (no per-poll spam). Uses `UserNotifications`, guarded with `#available(macOS 10.14, *)` so the minimum OS is unchanged — notifications simply activate on 10.14+.
- **24-hour trend chart** — a sparkline in the popover drawn with Core Graphics (no dependency, stays universal). Each line segment and its fill band is drawn in the same category color the menu bar uses (green/yellow/orange/red/purple/black), with a soft glow and a category-colored dot on the latest reading, so the chart reads as the same scale as the status item. History is a rolling 24 hours pruned by timestamp (robust to sleep gaps) and **resets when the zip code changes** so locations aren’t mixed.

## Supporting changes
- The fetch completion now passes the worst `AirQualityDatum` so the AQI value, category, and reporting area are available to both features.
- Adds a `.gitignore` for Xcode build artifacts and per-user state.

## Testing
- Builds clean (`BUILD SUCCEEDED`) on the 10.13 target.
- Verified history records the correct worst-parameter AQI and persists as JSON; chart rendering checked via an offscreen render; notification copy verified.